### PR TITLE
file to create one-shot training set and test set folders from CelebA…

### DIFF
--- a/celeba_one_shot_train_test_split.ipynb
+++ b/celeba_one_shot_train_test_split.ipynb
@@ -1,0 +1,513 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Creating One-Shot Train Set & Test Set Folders from CelebA Dataset\n",
+    "\n",
+    "**Only run this .ipynb file ONCE to create the one-shot train img folder & test img folder**\n",
+    "\n",
+    "**One-Shot Train Folder Location: 'data/train_celeba_one_shot'**\n",
+    "\n",
+    "**Test Folder Location: 'data/test_celeba**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import shutil\n",
+    "import src\n",
+    "from src.utils.celeba_helper import CelebADataset\n",
+    "from torch.utils.data import Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load CelebA Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Load the dataset\n",
+    "# Path to directory with all the images and mapping\n",
+    "img_folder = 'data/img_align_celeba'\n",
+    "mapping_file = 'data/identity_CelebA.txt'\n",
+    "\n",
+    "# Load the dataset from file\n",
+    "celeba_dataset = CelebADataset(img_folder, mapping_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>000001.jpg</td>\n",
+       "      <td>2880</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>000002.jpg</td>\n",
+       "      <td>2937</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>000003.jpg</td>\n",
+       "      <td>8692</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>000004.jpg</td>\n",
+       "      <td>5805</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>000005.jpg</td>\n",
+       "      <td>9295</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    file_name  person_id\n",
+       "0  000001.jpg       2880\n",
+       "1  000002.jpg       2937\n",
+       "2  000003.jpg       8692\n",
+       "3  000004.jpg       5805\n",
+       "4  000005.jpg       9295"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# labels file dataframe\n",
+    "file_label_mapping = celeba_dataset.file_label_mapping\n",
+    "display(file_label_mapping.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of Images in CelebA Dataset is: 202599 images\n",
+      "Number of Unique Persons in CelebA Dataset is: 10177 persons\n"
+     ]
+    }
+   ],
+   "source": [
+    "# How many images are in the CelebA Dataset and how many unique persons are there?\n",
+    "print(f'Number of Images in CelebA Dataset is: {len(celeba_dataset)} images')\n",
+    "print(f'Number of Unique Persons in CelebA Dataset is: {file_label_mapping.person_id.nunique()} persons')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create & Load One-Shot Training Folder from CelebA\n",
+    "\n",
+    "There are 10,177 unique persons in the CelebA Dataset. \n",
+    "\n",
+    "The Training Set will contain the **FIRST** file_name for each person_id in the file_label_mapping dataframe\n",
+    "\n",
+    "**1 img for each person (10,177 images)**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create One-Shot Training Folder\n",
+    "train_dir = 'data/train_celeba_one_shot'\n",
+    "\n",
+    "if not os.path.exists(train_dir):\n",
+    "  os.makedirs(train_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>000001.jpg</td>\n",
+       "      <td>2880</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>000002.jpg</td>\n",
+       "      <td>2937</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>000003.jpg</td>\n",
+       "      <td>8692</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>000004.jpg</td>\n",
+       "      <td>5805</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>000005.jpg</td>\n",
+       "      <td>9295</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    file_name  person_id\n",
+       "0  000001.jpg       2880\n",
+       "1  000002.jpg       2937\n",
+       "2  000003.jpg       8692\n",
+       "3  000004.jpg       5805\n",
+       "4  000005.jpg       9295"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of Images in One-Shot Training Data is: 10177 images\n",
+      "Number of Unique Persons in One-Shot Training Data is: 10177 persons\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Obtain the first file_name for each person_id in the file_label_mapping dataframe\n",
+    "train_df = file_label_mapping.drop_duplicates(subset='person_id', keep='first', inplace=False, ignore_index=False)\n",
+    "display(train_df.head())\n",
+    "\n",
+    "print(f'Number of Images in One-Shot Training Data is: {len(train_df)} images')\n",
+    "print(f'Number of Unique Persons in One-Shot Training Data is: {train_df.person_id.nunique()} persons')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "One Shot CelebA Training Data is copied\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get list of the file paths for the training images - one-shot\n",
+    "train_file_paths = [os.path.join(img_folder, file_name).replace('\\\\','/') for file_name in train_df.file_name]\n",
+    "\n",
+    "# Copy-pasting images (source path, destination path)\n",
+    "for name in train_file_paths:\n",
+    "    shutil.copy(name, train_dir)\n",
+    "\n",
+    "print('One Shot CelebA Training Data is copied')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create & Load Test Folder - CelebA\n",
+    "\n",
+    "All other images in the CelebA dataset that are not part of the one-shot training will become the test set\n",
+    "\n",
+    "This means that while the train set will only contain 1 image of each unique person, the test set may contain multiple images of a person. Additionally, if in the original CelebA Dataset, there is only 1 image of a certain person, that image will only appear in the training set and there will be no image of that person in the test set. This means that each unique person (10,177) in the training set may not have a corresponding image in the test set. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create Test Folder\n",
+    "test_dir = 'data/test_celeba'\n",
+    "\n",
+    "if not os.path.exists(test_dir):\n",
+    "  os.makedirs(test_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>000050.jpg</td>\n",
+       "      <td>1058</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>81</th>\n",
+       "      <td>000082.jpg</td>\n",
+       "      <td>4407</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>209</th>\n",
+       "      <td>000210.jpg</td>\n",
+       "      <td>3602</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>227</th>\n",
+       "      <td>000228.jpg</td>\n",
+       "      <td>3422</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>251</th>\n",
+       "      <td>000252.jpg</td>\n",
+       "      <td>4960</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      file_name  person_id\n",
+       "49   000050.jpg       1058\n",
+       "81   000082.jpg       4407\n",
+       "209  000210.jpg       3602\n",
+       "227  000228.jpg       3422\n",
+       "251  000252.jpg       4960"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of Images in Test Data is: 192422 images\n",
+      "Number of Unique Persons in Test Data is: 10133 persons\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Drop ALL the Indexes in the training set (train_df) from the original file_label_mapping df, and what is left is the images for the test set\n",
+    "test_df = file_label_mapping.drop(train_df.index, axis=0, inplace=False)\n",
+    "display(test_df.head())\n",
+    "\n",
+    "print(f'Number of Images in Test Data is: {len(test_df)} images')\n",
+    "print(f'Number of Unique Persons in Test Data is: {test_df.person_id.nunique()} persons')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CelebA Testing Data is copied\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get list of the file paths for the testing images \n",
+    "test_file_paths = [os.path.join(img_folder, file_name).replace('\\\\','/') for file_name in test_df.file_name]\n",
+    "\n",
+    "# Copy-pasting images (source path, destination path)\n",
+    "for name in test_file_paths:\n",
+    "    shutil.copy(name, test_dir)\n",
+    "\n",
+    "print('CelebA Testing Data is copied')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Orig CelebA, Train One-Shot, Test Split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original CelebA Dataset\n",
+      "Number of Images in CelebA Dataset is: 202599 images\n",
+      "Number of Unique Persons in CelebA Dataset is: 10177 persons\n",
+      "_____________________________________________________________\n",
+      "One Shot Training Set\n",
+      "Number of Images in One-Shot Training Data is: 10177 images\n",
+      "Number of Unique Persons in One-Shot Training Data is: 10177 persons\n",
+      "_____________________________________________________________\n",
+      "Testing Set\n",
+      "Number of Images in Test Data is: 192422 images\n",
+      "Number of Unique Persons in Test Data is: 10133 persons\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Original CelebA Dataset')\n",
+    "print(f'Number of Images in CelebA Dataset is: {len(celeba_dataset)} images')\n",
+    "print(f'Number of Unique Persons in CelebA Dataset is: {file_label_mapping.person_id.nunique()} persons')\n",
+    "\n",
+    "print('_____________________________________________________________')\n",
+    "\n",
+    "print('One Shot Training Set')\n",
+    "print(f'Number of Images in One-Shot Training Data is: {len(train_df)} images')\n",
+    "print(f'Number of Unique Persons in One-Shot Training Data is: {train_df.person_id.nunique()} persons')\n",
+    "\n",
+    "print('_____________________________________________________________')\n",
+    "\n",
+    "print('Testing Set')\n",
+    "print(f'Number of Images in Test Data is: {len(test_df)} images')\n",
+    "print(f'Number of Unique Persons in Test Data is: {test_df.person_id.nunique()} persons')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.6.9 ('one-shot-face-recognition')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "f833007afcffe21c80cae9ab338ea0326c55dd31c5b96c817689339d3442c56e"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
File to Create One-Shot Training Set & Test Set Folders from CelebA Dataset
Created **celeba_one_shot_train_test_split.ipynb** --> file is to be run once

- One-Shot Train Set Folder - contains 1 image file for each person (10,177 images)
- Test Set Folder - contains the rest of the image files (since the test set is much larger ~192,000 images, it took ~25 min to copy the files on cpu)