### PR TITLE
Create Standardized Train Test Split for CelebA For Future Experiments

### DIFF
--- a/standardized_celeba_train_test_split.ipynb
+++ b/standardized_celeba_train_test_split.ipynb
@@ -1,0 +1,1053 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Creating Standardized Train Set & Test Set Folders from CelebA Dataset\n",
+    "\n",
+    "**Only run this .ipynb file ONCE to create the train img folder & test img folder**\n",
+    "\n",
+    "**Train Folder Location: 'data/train_celeba_std'**\n",
+    "\n",
+    "**Test Folder Location: 'data/test_celeba_std**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import shutil\n",
+    "import src\n",
+    "from src.utils.celeba_helper import CelebADataset\n",
+    "from torch.utils.data import Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load CelebA Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Load the dataset\n",
+    "# Path to directory with all the images and mapping\n",
+    "img_folder = 'data/img_align_celeba'\n",
+    "mapping_file = 'data/identity_CelebA.txt'\n",
+    "\n",
+    "# Load the dataset from file\n",
+    "celeba_dataset = CelebADataset(img_folder, mapping_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>000001.jpg</td>\n",
+       "      <td>2880</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>000002.jpg</td>\n",
+       "      <td>2937</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>000003.jpg</td>\n",
+       "      <td>8692</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>000004.jpg</td>\n",
+       "      <td>5805</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>000005.jpg</td>\n",
+       "      <td>9295</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    file_name  person_id\n",
+       "0  000001.jpg       2880\n",
+       "1  000002.jpg       2937\n",
+       "2  000003.jpg       8692\n",
+       "3  000004.jpg       5805\n",
+       "4  000005.jpg       9295"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# labels file dataframe\n",
+    "file_label_mapping = celeba_dataset.file_label_mapping\n",
+    "display(file_label_mapping.head())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of Images in CelebA Dataset is: 202599 images\n",
+      "Number of Unique Persons in CelebA Dataset is: 10177 persons\n"
+     ]
+    }
+   ],
+   "source": [
+    "# How many images are in the CelebA Dataset and how many unique persons are there?\n",
+    "print(f'Number of Images in CelebA Dataset is: {len(celeba_dataset)} images')\n",
+    "print(f'Number of Unique Persons in CelebA Dataset is: {file_label_mapping.person_id.nunique()} persons')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get First File For Each Unique Person in CelebA\n",
+    "These files will be in the train set (10,177 images)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10177\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>000001.jpg</td>\n",
+       "      <td>2880</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>000002.jpg</td>\n",
+       "      <td>2937</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>000003.jpg</td>\n",
+       "      <td>8692</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>000004.jpg</td>\n",
+       "      <td>5805</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>000005.jpg</td>\n",
+       "      <td>9295</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    file_name  person_id\n",
+       "0  000001.jpg       2880\n",
+       "1  000002.jpg       2937\n",
+       "2  000003.jpg       8692\n",
+       "3  000004.jpg       5805\n",
+       "4  000005.jpg       9295"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "first_img_file = file_label_mapping.drop_duplicates(subset='person_id', keep='first', inplace=False, ignore_index=False)\n",
+    "print(len(first_img_file))\n",
+    "first_img_file.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "192422\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>000050.jpg</td>\n",
+       "      <td>1058</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>81</th>\n",
+       "      <td>000082.jpg</td>\n",
+       "      <td>4407</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>209</th>\n",
+       "      <td>000210.jpg</td>\n",
+       "      <td>3602</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>227</th>\n",
+       "      <td>000228.jpg</td>\n",
+       "      <td>3422</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>251</th>\n",
+       "      <td>000252.jpg</td>\n",
+       "      <td>4960</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      file_name  person_id\n",
+       "49   000050.jpg       1058\n",
+       "81   000082.jpg       4407\n",
+       "209  000210.jpg       3602\n",
+       "227  000228.jpg       3422\n",
+       "251  000252.jpg       4960"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# remaining images after removing first_img_file\n",
+    "rest = file_label_mapping.drop(first_img_file.index, axis=0, inplace=False)\n",
+    "print(len(rest))\n",
+    "rest.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Second File For Each Unique Person Remaining in CelebA \n",
+    "These files will be in the test set (10,133 images)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10133\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>000050.jpg</td>\n",
+       "      <td>1058</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>81</th>\n",
+       "      <td>000082.jpg</td>\n",
+       "      <td>4407</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>209</th>\n",
+       "      <td>000210.jpg</td>\n",
+       "      <td>3602</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>227</th>\n",
+       "      <td>000228.jpg</td>\n",
+       "      <td>3422</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>251</th>\n",
+       "      <td>000252.jpg</td>\n",
+       "      <td>4960</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      file_name  person_id\n",
+       "49   000050.jpg       1058\n",
+       "81   000082.jpg       4407\n",
+       "209  000210.jpg       3602\n",
+       "227  000228.jpg       3422\n",
+       "251  000252.jpg       4960"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "second_img_file = rest.drop_duplicates(subset='person_id', keep='first', inplace=False, ignore_index=False)\n",
+    "print(len(second_img_file))\n",
+    "second_img_file.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "182289\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>290</th>\n",
+       "      <td>000291.jpg</td>\n",
+       "      <td>4960</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>783</th>\n",
+       "      <td>000784.jpg</td>\n",
+       "      <td>3272</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>807</th>\n",
+       "      <td>000808.jpg</td>\n",
+       "      <td>1250</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>912</th>\n",
+       "      <td>000913.jpg</td>\n",
+       "      <td>6546</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>949</th>\n",
+       "      <td>000950.jpg</td>\n",
+       "      <td>2688</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      file_name  person_id\n",
+       "290  000291.jpg       4960\n",
+       "783  000784.jpg       3272\n",
+       "807  000808.jpg       1250\n",
+       "912  000913.jpg       6546\n",
+       "949  000950.jpg       2688"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# remaining images after removing both first_img_file and second_img_file\n",
+    "rest.drop(second_img_file.index, axis=0, inplace=True)\n",
+    "print(len(rest))\n",
+    "rest.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Standardized Test Set will contain 35,000 Total Images\n",
+    "Test Set Contains: 10,133 images (second_file_img) + ~24867 randomly sampled = 35,000 Images Total\n",
+    "\n",
+    "It is necessary that the train set contains all the unique persons in Celeba (10,177) but the test set may not**\n",
+    "\n",
+    "**some people only have 1 image of themselves in the dataset and will only appear in train but not test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "24867\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>109075</th>\n",
+       "      <td>109076.jpg</td>\n",
+       "      <td>9681</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>150494</th>\n",
+       "      <td>150495.jpg</td>\n",
+       "      <td>3916</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>125212</th>\n",
+       "      <td>125213.jpg</td>\n",
+       "      <td>8092</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>150599</th>\n",
+       "      <td>150600.jpg</td>\n",
+       "      <td>8867</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>112345</th>\n",
+       "      <td>112346.jpg</td>\n",
+       "      <td>6686</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         file_name  person_id\n",
+       "109075  109076.jpg       9681\n",
+       "150494  150495.jpg       3916\n",
+       "125212  125213.jpg       8092\n",
+       "150599  150600.jpg       8867\n",
+       "112345  112346.jpg       6686"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# sample the remaining images (after dropping first_img_file and second_img_file) in the rest df randomly that will go with the second_img_file for test set (35,000)\n",
+    "test_sample = rest.sample(n=35000-10133, random_state=42)\n",
+    "print(len(test_sample))\n",
+    "test_sample.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "157422\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>290</th>\n",
+       "      <td>000291.jpg</td>\n",
+       "      <td>4960</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>783</th>\n",
+       "      <td>000784.jpg</td>\n",
+       "      <td>3272</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>807</th>\n",
+       "      <td>000808.jpg</td>\n",
+       "      <td>1250</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>912</th>\n",
+       "      <td>000913.jpg</td>\n",
+       "      <td>6546</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>949</th>\n",
+       "      <td>000950.jpg</td>\n",
+       "      <td>2688</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      file_name  person_id\n",
+       "290  000291.jpg       4960\n",
+       "783  000784.jpg       3272\n",
+       "807  000808.jpg       1250\n",
+       "912  000913.jpg       6546\n",
+       "949  000950.jpg       2688"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# get the reamining images that are left that will go in the train set with the first_img_file\n",
+    "rest.drop(test_sample.index, axis=0, inplace=True)\n",
+    "print(len(rest))\n",
+    "rest.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create CelebA Train DataFrame & Load into Train Folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create One-Shot Training Folder\n",
+    "train_dir = 'data/train_celeba_std'\n",
+    "\n",
+    "if not os.path.exists(train_dir):\n",
+    "  os.makedirs(train_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "167599\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>000001.jpg</td>\n",
+       "      <td>2880</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>000002.jpg</td>\n",
+       "      <td>2937</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>000003.jpg</td>\n",
+       "      <td>8692</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>000004.jpg</td>\n",
+       "      <td>5805</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>000005.jpg</td>\n",
+       "      <td>9295</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    file_name  person_id\n",
+       "0  000001.jpg       2880\n",
+       "1  000002.jpg       2937\n",
+       "2  000003.jpg       8692\n",
+       "3  000004.jpg       5805\n",
+       "4  000005.jpg       9295"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# concat the 10,177 first_img_file + the remaining 157,422 images to create the new train set\n",
+    "train_df = pd.concat([first_img_file, rest]).sort_values(by='file_name')\n",
+    "print(len(train_df))\n",
+    "train_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CelebA Training Data is copied\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get list of the file paths for the training images - one-shot\n",
+    "train_file_paths = [os.path.join(img_folder, file_name).replace('\\\\','/') for file_name in train_df.file_name]\n",
+    "\n",
+    "# Copy-pasting images (source path, destination path)\n",
+    "for name in train_file_paths:\n",
+    "    shutil.copy(name, train_dir)\n",
+    "\n",
+    "print('CelebA Training Data is copied')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create CelebA Test DataFrame & Load into Test Folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create Test Folder\n",
+    "test_dir = 'data/test_celeba_std'\n",
+    "\n",
+    "if not os.path.exists(test_dir):\n",
+    "  os.makedirs(test_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "35000\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>person_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>000050.jpg</td>\n",
+       "      <td>1058</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>81</th>\n",
+       "      <td>000082.jpg</td>\n",
+       "      <td>4407</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>209</th>\n",
+       "      <td>000210.jpg</td>\n",
+       "      <td>3602</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>227</th>\n",
+       "      <td>000228.jpg</td>\n",
+       "      <td>3422</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>251</th>\n",
+       "      <td>000252.jpg</td>\n",
+       "      <td>4960</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      file_name  person_id\n",
+       "49   000050.jpg       1058\n",
+       "81   000082.jpg       4407\n",
+       "209  000210.jpg       3602\n",
+       "227  000228.jpg       3422\n",
+       "251  000252.jpg       4960"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# concat the 10,133 second_img_file + the 24867 test_sample to create the 35,000 image test set\n",
+    "test_df = pd.concat([second_img_file, test_sample]).sort_values(by='file_name')\n",
+    "print(len(test_df))\n",
+    "test_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CelebA Testing Data is copied\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get list of the file paths for the testing images \n",
+    "test_file_paths = [os.path.join(img_folder, file_name).replace('\\\\','/') for file_name in test_df.file_name]\n",
+    "\n",
+    "# Copy-pasting images (source path, destination path)\n",
+    "for name in test_file_paths:\n",
+    "    shutil.copy(name, test_dir)\n",
+    "\n",
+    "print('CelebA Testing Data is copied')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Review of CelebA Training/Test Split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original CelebA Dataset\n",
+      "Number of Images in CelebA Dataset is: 202599 images\n",
+      "Number of Unique Persons in CelebA Dataset is: 10177 persons\n",
+      "_____________________________________________________________\n",
+      "One Shot Training Set\n",
+      "Number of Images in Training Data is: 167599 images\n",
+      "Number of Unique Persons in One-Shot Training Data is: 10177 persons\n",
+      "_____________________________________________________________\n",
+      "Testing Set\n",
+      "Number of Images in Test Data is: 35000 images\n",
+      "Number of Unique Persons in Test Data is: 10133 persons\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Original CelebA Dataset')\n",
+    "print(f'Number of Images in CelebA Dataset is: {len(celeba_dataset)} images')\n",
+    "print(f'Number of Unique Persons in CelebA Dataset is: {file_label_mapping.person_id.nunique()} persons')\n",
+    "\n",
+    "print('_____________________________________________________________')\n",
+    "\n",
+    "print('One Shot Training Set')\n",
+    "print(f'Number of Images in Training Data is: {len(train_df)} images')\n",
+    "print(f'Number of Unique Persons in One-Shot Training Data is: {train_df.person_id.nunique()} persons')\n",
+    "\n",
+    "print('_____________________________________________________________')\n",
+    "\n",
+    "print('Testing Set')\n",
+    "print(f'Number of Images in Test Data is: {len(test_df)} images')\n",
+    "print(f'Number of Unique Persons in Test Data is: {test_df.person_id.nunique()} persons')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.6.9 ('one-shot-face-recognition')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "f833007afcffe21c80cae9ab338ea0326c55dd31c5b96c817689339d3442c56e"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Train Set Contains: 167,599 images
Test Set Contains: 35,000 Images
New File: standardized_celeba_train_test_split.ipynb Uses src.utils.celeba_helper CelebADataset