### PR TITLE
Fixed Error in find_positive_observations in celeba_helper.py

### DIFF
--- a/src/utils/celeba_helper.py
+++ b/src/utils/celeba_helper.py
@@ -160,8 +160,8 @@ class CelebADataset(Dataset):
             #pos_examples = df[df['person_id']==int(anchor)]['file_id'].values        
             pos_examples = df[df['person_id']==int(anchor)].index.values
 
-            if sample and len(pos_examples)!=0:
-                pos_examples = np.random.choice(pos_examples, size=num_examples)
+            if sample and len(pos_examples) > num_examples:
+                pos_examples = np.random.choice(pos_examples, size=num_examples, replace=False)
 
             pos_obs_idx = np.hstack([pos_obs_idx, pos_examples])
 


### PR DESCRIPTION
During sampling pos_examples, the original code uses np.random.choice which by default samples with replacement. This needs to be changed to replace=False so we don't retrieve the same positive sample more than once. Additionally, if sample=True, we must check that the len(pos_examples) > num_examples otherwise we would be trying to take a larger sample than the population